### PR TITLE
Add conditional rendering to handle supplied alt values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_heroicon (1.0.1)
+    rails_heroicon (1.0.2)
       rails
 
 GEM

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ However, this can be over-written with the `size` attribute.
 `rails_heroicon` automatically sets `aria-hidden="true"` if `aria-label` is not
 set, and if `aria-label` is set, then `role="img"` is set.
 
+### Tooltip
+
+You can provide tooltips on hover if you pass in a `:title` option. Anything passed into the `:title` option will be rendered inside of a <title> tag within the rendered SVG, which modern browsers will lean on to display a tooltip on hover.
+
 ## Development
 
 - Clone the repo

--- a/lib/rails_heroicon/helper.rb
+++ b/lib/rails_heroicon/helper.rb
@@ -32,9 +32,6 @@ module RailsHeroicon
     # == Accessibility
     # The helper method automatically sets <tt>aria-hidden=true</tt> if <tt>aria-label</tt> is not set, and
     # if <tt>aria-label</tt> is set, then <tt>role=img</tt> is set automatically.
-    #
-    # You can provide tooltips on hover if you pass in a `:title` option. Anything passed into the `:title` option
-    # will be rendered inside of a <title> tag within the rendered SVG.
     def heroicon(symbol, title: nil, **options)
       icon = RailsHeroicon.new(symbol, **options)
 

--- a/lib/rails_heroicon/helper.rb
+++ b/lib/rails_heroicon/helper.rb
@@ -33,21 +33,13 @@ module RailsHeroicon
     # The helper method automatically sets <tt>aria-hidden=true</tt> if <tt>aria-label</tt> is not set, and
     # if <tt>aria-label</tt> is set, then <tt>role=img</tt> is set automatically.
     #
-    # You can provide tooltips on hover if you pass in an `:alt` option. Anything passed into the `:alt` option
+    # You can provide tooltips on hover if you pass in a `:title` option. Anything passed into the `:title` option
     # will be rendered inside of a <title> tag within the rendered SVG.
-    def heroicon(symbol, **options)
+    def heroicon(symbol, title: nil, **options)
       icon = RailsHeroicon.new(symbol, **options)
 
-      if alt = options.delete(:alt)
-        content_tag(:svg, icon.options) do
-          [
-            content_tag(:title, alt),
-            icon.svg_path
-          ].join.html_safe
-        end
-      else
-        content_tag(:svg, icon.svg_path.html_safe, icon.options)
-      end
+      title_tag = content_tag(:title, title) if title
+      content_tag(:svg, title_tag.to_s.html_safe + icon.svg_path.html_safe, icon.options)
     end
   end
 end

--- a/lib/rails_heroicon/helper.rb
+++ b/lib/rails_heroicon/helper.rb
@@ -32,9 +32,22 @@ module RailsHeroicon
     # == Accessibility
     # The helper method automatically sets <tt>aria-hidden=true</tt> if <tt>aria-label</tt> is not set, and
     # if <tt>aria-label</tt> is set, then <tt>role=img</tt> is set automatically.
+    #
+    # You can provide tooltips on hover if you pass in an `:alt` option. Anything passed into the `:alt` option
+    # will be rendered inside of a <title> tag within the rendered SVG.
     def heroicon(symbol, **options)
       icon = RailsHeroicon.new(symbol, **options)
-      content_tag(:svg, icon.svg_path.html_safe, icon.options)
+
+      if alt = options.delete(:alt)
+        content_tag(:svg, icon.options) do
+          [
+            content_tag(:title, alt),
+            icon.svg_path
+          ].join.html_safe
+        end
+      else
+        content_tag(:svg, icon.svg_path.html_safe, icon.options)
+      end
     end
   end
 end

--- a/spec/rails_heroicon/helper_spec.rb
+++ b/spec/rails_heroicon/helper_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe RailsHeroicon::Helper do
+  before do
+    helper = Class.new do
+      include RailsHeroicon::Helper
+      include ActionView::Helpers::TagHelper
+    end
+
+    stub_const("Heroicon", helper)
+  end
+
+  describe "#heroicon" do
+    context "when title is specified" do
+      it "renders the title tag" do
+        icon = Heroicon.new.heroicon("user", title: "My title")
+
+        expect(icon).to match(/<title>My title<\/title>/)
+      end
+    end
+
+    context "when title is not specified" do
+      it "does not render the title tag" do
+        icon = Heroicon.new.heroicon("user")
+
+        expect(icon).not_to match(/<title>/)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "rails_heroicon"
+require "rails_heroicon/helper"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Closes https://github.com/abeidahmed/rails-heroicon/issues/13

Updates the `heroicon` helper to optionally render a `title` tag if an `:alt` option is provided.