### PR TITLE
Add a link in the docs to the specific heroicon release that the gem is built with

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 Ruby on Rails views helper for the awesome heroicons by Steve Schoger. To see
 all the icons visit [heroicons](https://heroicons.com/).
 
-292 icons included as of today.
+The latest version of this gem is built with heroicons
+[v2.0.16](https://github.com/tailwindlabs/heroicons/releases/tag/v2.0.16) (292
+icons).
 
 > This gem has no official affiliation with [Tailwind Labs](https://github.com/tailwindlabs),
 > yet.


### PR DESCRIPTION
This addresses: https://github.com/abeidahmed/rails-heroicon/issues/33

In the issue I suggested adding this to the docs:

> The latest rails_heroicon is built with Heroicons [v2.0.16](https://github.com/tailwindlabs/heroicons/releases) (292 icons)

I made 3 changes to the above for this PR:

- I replaced the gem name with a more generic "of this gem" because at this point in the readme the gem's name isn't mentioned yet, you also referenced your gem as "This gem" in the affiliate sentence under it so I kept it consistent
- I used a lower case heroicons to match their branding (their site's logo has it as lower case)
- I didn't use a blockquote because you already had a blockquote for the affiliation sentence and it looked weird to have 2 blockquotes next to each other, they were competing for attention

I tried to make it stand out more with bold or italics but it felt too busy with all of the different styles going on near there.