### PR TITLE
perf: cache icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   ```erb
   <%= heroicon "user", variant: "outline", "stroke-width": 2 %>
   ```
+- Cache repeating icons using `mattr_cache`
 
 ## 2.1.1
 

--- a/lib/rails_heroicon/helper.rb
+++ b/lib/rails_heroicon/helper.rb
@@ -3,6 +3,8 @@ require "action_view"
 module RailsHeroicon
   module Helper
     include ActionView::Helpers::TagHelper
+
+    mattr_accessor :icon_cache, default: {}
     # To add a heroicon, call <tt><%= heroicon "icon_name" %></tt> on your erb template.
     # Head over to https://heroicons.com to view all the icons.
     #
@@ -34,10 +36,14 @@ module RailsHeroicon
     # The helper method automatically sets <tt>aria-hidden=true</tt> if <tt>aria-label</tt> is not set, and
     # if <tt>aria-label</tt> is set, then <tt>role=img</tt> is set automatically.
     def heroicon(symbol, title: nil, **options)
-      icon = RailsHeroicon.new(symbol, **options)
+      cache_key = [symbol, title, options]
+      return icon_cache[cache_key] if icon_cache[cache_key]
 
+      icon = RailsHeroicon.new(symbol, **options)
       title_tag = content_tag(:title, title) if title
-      content_tag(:svg, title_tag.to_s.html_safe + icon.svg_path.html_safe, icon.options)
+      tag = content_tag(:svg, title_tag.to_s.html_safe + icon.svg_path.html_safe, icon.options)
+      icon_cache[cache_key] = tag
+      tag
     end
   end
 end

--- a/spec/rails_heroicon/helper_spec.rb
+++ b/spec/rails_heroicon/helper_spec.rb
@@ -1,3 +1,5 @@
+require "nokogiri"
+
 RSpec.describe RailsHeroicon::Helper do
   before do
     helper = Class.new do
@@ -11,16 +13,25 @@ RSpec.describe RailsHeroicon::Helper do
     context "when title is specified" do
       it "renders the title tag" do
         icon = Heroicon.new.heroicon("user", title: "My title")
+        doc = Nokogiri::HTML::DocumentFragment.parse(icon)
 
-        expect(icon).to match(/<title>My title<\/title>/)
+        expect(doc.css("title").children[0].text).to eq("My title")
+      end
+
+      it "does not add the title attribute to the svg element" do
+        icon = Heroicon.new.heroicon("user", title: "My title")
+        doc = Nokogiri::HTML::DocumentFragment.parse(icon)
+
+        expect(doc.css("svg")[0]["title"]).to be_blank
       end
     end
 
     context "when title is not specified" do
       it "does not render the title tag" do
         icon = Heroicon.new.heroicon("user")
+        doc = Nokogiri::HTML::DocumentFragment.parse(icon)
 
-        expect(icon).not_to match(/<title>/)
+        expect(doc.css("title")).to be_blank
       end
     end
   end

--- a/spec/rails_heroicon/rails_heroicon_spec.rb
+++ b/spec/rails_heroicon/rails_heroicon_spec.rb
@@ -1,5 +1,3 @@
-require "byebug"
-
 RSpec.describe RailsHeroicon::RailsHeroicon do
   describe "#initialize" do
     it "sets the icon name" do


### PR DESCRIPTION
## Description
This PR makes the assumption that most of the icons are being repeated on your HTML page. If that's the case, this will improve the rendering speed of the icons.

## Acknowledgements
https://github.com/primer/octicons/blob/main/lib/octicons_helper/lib/octicons_helper/helper.rb

See https://github.com/abeidahmed/rails-heroicon/issues/34#issuecomment-1445336348